### PR TITLE
set ALLOWED_ORIGINS for production CORS

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -22,5 +22,7 @@ services:
         value: "true"
       - key: RAILS_SERVE_STATIC_FILES
         value: "true"
+      - key: ALLOWED_ORIGINS
+        value: "https://stock-market-practice.netlify.app"
       - key: SECRET_KEY_BASE
         generateValue: true


### PR DESCRIPTION
Adds the Netlify frontend URL to render.yaml so the CORS config allows requests from the deployed app.

https://claude.ai/code/session_013sunP1rBswzHJuGfALkaA5